### PR TITLE
Add new keywords in `sqlind-sqlplus-directive'.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -162,7 +162,7 @@ a strinf or comment."
 
 (defconst sqlind-sqlplus-directive
   (concat "^"
-	  (regexp-opt '("column" "set" "rem" "define" "spool") t)
+	  (regexp-opt '("column" "set" "rem" "define" "spool" "prompt" "clear" "compute" "whenever") t)
 	  "\\b")
   "Match an SQL*Plus directive at the beginning of a line.
 A directive always stands on a line by itself -- we use that to


### PR DESCRIPTION
This change allow me to automatic indent my package creation's files:
``` sql
SET VERIFY OFF
WHENEVER SQLERROR EXIT FAILURE ROLLBACK;
WHENEVER OSERROR EXIT FAILURE ROLLBACK;

SET DEFINE OFF
SET SERVEROUTPUT ON SIZE 1000000 format wrapped

PROMPT ==============================================================
PROMPT Creating package MY_PACKAGE_PKG
PROMPT ==============================================================

CREATE OR REPLACE PACKAGE my_package_pkg
IS
...
```

Do you know how I could add some tests files to check the non regression ?

P.S.
Happy new year !!!