### PR TITLE
Correct indentation of comments inside a block.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1059,7 +1059,11 @@ purposes. "
 	     (syntax-symbol (if (symbolp syntax) syntax (nth 0 syntax))))
         
         (goto-char pos)
-        
+	(when (and (not (eq syntax-symbol 'comment-continuation))
+		(looking-at sqlind-comment-start-skip))
+	  (forward-line -1)
+	  (back-to-indentation))
+
 	(cond
 	  ;; do we start a comment?
 	  ((and (not (eq syntax-symbol 'comment-continuation))


### PR DESCRIPTION
ex:
begin
  first_instruction;

  -- a comment

  second_instruction; -- align with previous instruction.
end;
/