### PR TITLE
Add support for assignment and arrow (=>) in align.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1694,21 +1694,41 @@ determine how to indent each type of syntactic element."
 ;;; alignment rules
 
 (defvar sqlind-align-rules
-  ;; Line up he two sides of an equal sign in an update expression
-  `((sql-update-lineup-equals
-     (regexp . , ".*?\\(\\s *\\)=\\(\\s *\\).*")
-     (modes . '(sql-mode))
-     (group . (1 2))
+  '(;; Line up the two side of arrow =>
+    (sql-arrow-lineup
+     (regexp . "\\(\\s-*\\)=>\\(\\s-*\\)")
+     (modes quote (sql-mode))
+     (group 1 2)
+     (case-fold . t)
+     (repeat . t))
+    ;; Line up the two sides of an assigment
+    (sql-assign-lineup
+     (regexp . "\\(\\s-*\\):=\\(\\s-*\\)")
+     (modes quote (sql-mode))
+     (group 1 2)
+     (case-fold . t)
+     (repeat . t))
+    ;; Line up the two sides of in / out / in out parameter
+    (sql-param-lineup-in-out
+     (regexp . "\\(\\s-+\\)\\(in out\\|in\\|out\\)\\(\\s-+\\)")
+     (modes quote (sql-mode))
+     (group 1 3)
+     (case-fold . t)
+     (repeat . t))
+    ;; Line up the two sides of an equal sign in an update expression
+    (sql-equals
+     (regexp . "\\(\\s-*[^:]\\)=\\([^>]\\s-*\\)")
+     (modes quote (sql-mode))
+     (group 1 2)
      (case-fold . t)
      (repeat . t))
     ;; lineup the column aliases (the "as name" part) in a select statement
-    (sql-sqlect-lineup-column-names
-     (regexp . , ".*?\\(\\s +\\)as\\(\\s +\\).*")
-     (modes . '(sql-mode))
-     (group . (1 2))
+    (sql-select-lineup-column-names
+     (regexp . ".*?\\(\\s +\\)as\\(\\s +\\).*")
+     (modes quote (sql-mode))
+     (group 1 2)
      (case-fold . t)
-     (repeat . t))
-    )
+     (repeat . t)))
   "Align rules for SQL codes.
 
 These rules help aligning some SQL statements, such as the column


### PR DESCRIPTION
Allow to align some keywords in sql statements.
This version provides :
```sql
declare
  function dummy(p_param_1 in     varchar2,
                 p_param_2 in out varchar2,
                 p_param_2 out    varchar2)
  return   boolean;
  end dummy;

  function dummy_2(p_param_1 out varchar2,
                   p_param_2 out varchar2,
                   p_param_2 out varchar2)
  return   boolean;

  function dummy_3(p_param_1     varchar2,
                   p_param_2 in  varchar2,
                   p_param_2 out varchar2)
  return   boolean;

  var1 boolean      := true;
  var2 number       := 1;
  var42 varchar2(1) := 'Y';
begin
  if dummy(p_param_1  => val1,
           p_param_10 => val10) then
    null;
  end if;
end;
/
```
But do you think this could be improved to the code bellow ?
```sql
declare
  function dummy(p_param_1 in     varchar2,
                 p_param_2 in out varchar2,
                 p_param_2    out varchar2)
  return   boolean;
  end dummy;

  function dummy_2(p_param_1 out varchar2,
                   p_param_2 out varchar2,
                   p_param_2 out varchar2)
  return   boolean;

  function dummy_3(p_param_1     varchar2,
                   p_param_2 in  varchar2,
                   p_param_2 out varchar2)
  return   boolean;

  var1  boolean     := true;
  var2  number      := 1;
  var42 varchar2(1) := 'Y';
begin
  if dummy(p_param_1  => val1,
           p_param_10 => val10) then
    null;
  end if;
end;
/
```
The improvement are here 
```sql
  function dummy(p_param_1 in     varchar2,
                 p_param_2 in out varchar2,
                 p_param_2    out varchar2)
  return   boolean;
  end dummy;
```
and here
```sql
  var1  boolean     := true;
  var2  number      := 1;
  var42 varchar2(1) := 'Y';
```