### PR TITLE
Start workgin on aligning keywords left or right.

### DIFF
--- a/customize-indentation.md
+++ b/customize-indentation.md
@@ -112,6 +112,34 @@ The following functions are available as part of the package:
   paren, discard the current offset and return the column of the corresponding
   open paren.
 
+* `sqlind-lone-semicolon` -- Indent a lone semicolon with the statement start.
+
+* `sqlind-adjust-operator` -- Adjust the indentation for operators in
+  select clauses, it will
+  indent as follows:
+
+```sql
+    select col1, col2
+              || col3 as composed_column,
+           col4
+        || col5 as composed_column2
+    from   my_table
+    where  cond1 = 1
+    and    cond2 = 2;
+```
+
+* `sqlind-adjust-and-or-left` -- Align an AND, OR or NOT operator with
+the start of the WHERE clause.
+If this rule is added to the 'in-select-clause syntax after the
+`sqlind-lineup-to-clause-end' rule, it will adjust lines starting
+with AND, OR or NOT to be aligned so they sit left under the WHERE clause.
+
+* `sqlind-adjust-and-or-right` -- Align an AND, OR or NOT operator
+  with the end of the WHERE clause. If this rule is added to the
+  'in-select-clause syntax after the `sqlind-lineup-to-clause-end' rule,
+  it will adjust lines starting with AND, OR or NOT to be aligned so
+  they sit under the WHERE clause.
+
 * `sqlind-adjust-comma` -- if the line starts with a comma, adjust the current
   offset so that the line is indented to the first word character.  For
   example, if added to a 'select-column' syntax indentation rule, it will

--- a/sql-indent-left.el
+++ b/sql-indent-left.el
@@ -1,0 +1,189 @@
+;;; sql-indent-left.el --- configuration options to indent sql -*- lexical-binding: t -*-
+;;
+;; Filename: sql-indent-left.el
+;; Description:
+;; Author: pierre.techoueyres@free.fr
+;; Maintainer: pierre.techoueyres@free.fr
+;; Copyright (C) 2017, Pierre Téchoueyres all rights reserved.
+;; Created:
+;; Version: pierre.techoueyres@free.fr
+;; Last-Updated:
+;;           By:
+;;     Update #: 0
+;; URL:
+;; Keywords: language sql indentation
+;; Compatibility:
+;;
+;; Features that might be required by this library:
+;;
+;;   None
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; Set configuration options to indent sql my way.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Change log:
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(require 'sql-indent)
+
+(defun sqlind-adjust-operator-left (_syntax base-indentation)
+  "Adjust the indentation for operators in select clauses.
+
+Select columns are lined up to the operands, not the operators.
+For example.
+
+    select col1, col2
+              || col3 as composed_column,
+           col4
+        || col5 as composed_column2
+    from   my_table
+    where  cond1 = 1
+    and    cond2 = 2;
+
+This is an indentation adjuster and needs to be added to the
+`sqlind-indentation-offsets-alist`"
+  (save-excursion
+    (back-to-indentation)
+    ;; If there are non-word constituents at the beginning if the line,
+    ;; consider them an operator and line up the line to the first word of the
+    ;; line, not the operator
+    (cond ((looking-at "\\W+")
+	   (let ((ofs (length (match-string 0))))
+	     (forward-line -1)
+	     (end-of-line)
+	     (sqlind-backward-syntactic-ws)
+	     (forward-sexp -1)
+	     (- (current-column) ofs)))
+	  ('t base-indentation))))
+
+(defun sqlind-adjust-operator-right (_syntax base-indentation)
+  "Adjust the indentation for operators in select clauses.
+
+Select columns are lined up to the operands, not the operators.
+For example.
+
+  select col1, col2
+            || col3 as composed_column,
+         col4
+      || col5 as composed_column2
+    from my_table
+   where cond1 = 1
+     and cond2 = 2;
+
+This is an indentation adjuster and needs to be added to the
+`sqlind-indentation-offsets-alist`"
+  (save-excursion
+    (back-to-indentation)
+    ;; If there are non-word constituents at the beginning if the line,
+    ;; consider them an operator and line up the line to the first word of the
+    ;; line, not the operator
+    (cond ((looking-at "\\W+")
+	   (let ((ofs (length (match-string 0))))
+	     (forward-line -1)
+	     (end-of-line)
+	     (sqlind-backward-syntactic-ws)
+	     (forward-sexp -1)
+	     (- (current-column) ofs)))
+	  ((looking-at "\\(?:and\\|or\\|not\\)")
+	   (let ((ofs (length (match-string 0))))
+	     (+ base-indentation (- 5 ofs))))
+	  ('t base-indentation))))
+
+(defun sqlind-lone-semicolon (syntax base-indentation)
+  "Indent a lone semicolon with the statement start.  For example:
+
+    select col
+    from my_table
+    ;
+
+This is an indentation adjuster and needs to be added to the
+`sqlind-indentation-offsets-alist`"
+  (save-excursion
+    (back-to-indentation)
+    (if (looking-at ";")
+        (sqlind-use-anchor-indentation syntax base-indentation)
+      base-indentation)))
+
+(defvar sqlind-indentation-right-offsets-alist
+  `((select-column-continuation sqlind-indent-select-column
+                                sqlind-adjust-operator-left
+                                sqlind-lone-semicolon)
+    (in-select-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-right
+		      sqlind-lone-semicolon)
+    (in-delete-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-right
+		      sqlind-lone-semicolon)
+    (in-insert-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-right
+		      sqlind-lone-semicolon)
+    (in-update-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-right
+		      sqlind-lone-semicolon)
+    ;; mandatory 
+    (select-table-continuation sqlind-indent-select-table +
+                               sqlind-lone-semicolon)
+    ;; rest picked up from the original indentation offsets
+    ,@sqlind-default-indentation-offsets-alist))
+
+(defvar sqlind-indentation-left-offsets-alist
+  `((select-clause 0)
+    (insert-clause 0)
+    (delete-clause 0)
+    (update-clause 0)
+    (case-clause-item-cont 0)
+    (package +)
+    (package-body +)
+    (select-column-continuation sqlind-indent-select-column
+                                sqlind-adjust-operator-left
+                                sqlind-lone-semicolon)
+    (in-select-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-left
+                      sqlind-lone-semicolon)
+    (in-delete-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-left
+                      sqlind-lone-semicolon)
+    (in-insert-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-left
+                      sqlind-lone-semicolon)
+    (in-update-clause sqlind-lineup-to-clause-end
+                      sqlind-adjust-operator-left
+                      sqlind-lone-semicolon)
+    (select-table-continuation sqlind-indent-select-table +
+                               sqlind-lone-semicolon)
+    ;; rest picked up from the original indentation offsets
+    ,@sqlind-default-indentation-offsets-alist))
+
+;; (add-hook 'sql-mode-hook
+;;           (lambda ()
+;;             (setq sqlind-indentation-offsets-alist sqlind-indentation-left-offsets-alist)))
+
+(provide 'sql-indent-left)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; sql-indent-left.el ends here

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1952,8 +1952,9 @@ instead."
   (set (make-local-variable 'indent-line-function) 'sqlind-indent-line)
   (define-key sql-mode-map [remap beginning-of-defun] 'sqlind-beginning-of-statement)
   (setq align-mode-rules-list sqlind-align-rules)
-  (when (eq direction 'left)
-    (setq sqlind-indentation-offsets-alist sqlind-indentation-left-offsets-alist)))
+  (if (eq direction 'left)
+      (setq sqlind-indentation-offsets-alist sqlind-indentation-left-offsets-alist)
+    (setq sqlind-indentation-offsets-alist sqlind-indentation-right-offsets-alist)))
 
 ;; (add-hook 'sql-mode-hook
 ;;           (lambda ()

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1674,7 +1674,6 @@ indentation so that:
 If the clause is on a line by itself, the current line is
 indented by `sqlind-basic-offset', otherwise the current line is
 indented so that it starts in next column from where the clause
-<<<<<<< HEAD
 keyword ends."
   (destructuring-bind ((_sym clause) . anchor) (car syntax)
     (save-excursion
@@ -1702,36 +1701,6 @@ with AND or OR to be aligned so they sit under the WHERE clause."
                (looking-at "and\\|or"))
           (- base-indentation (1+ (- (match-end 0) (match-beginning 0))))
         base-indentation))))
-=======
-keyword ends.
-
-An exception is made for a 'where' clause: if the current line
-starts with an 'and' or an 'or' the line is indented so that the
-and/or is right justified with the 'where' clause."
-  (let ((origin (point)))
-    (destructuring-bind ((_sym clause) . anchor) (car syntax)
-      (save-excursion
-	(goto-char anchor)
-	(forward-char (1+ (length clause)))
-	(skip-syntax-forward " ")
-	(if (or (looking-at sqlind-comment-start-skip)
-		(looking-at "$"))
-	    ;; if the clause is on a line by itself, indent this line
-	    ;; with a sqlind-basic-offset
-	    (+ base-indentation sqlind-basic-offset)
-	    ;; otherwise, align to the end of the clause, with a few
-	    ;; exceptions
-	    (let ((indentation (current-column)))
-	      (goto-char origin)
-	      (back-to-indentation)
-	      ;; when the line starts with an 'and' or an 'or', line
-	      ;; it up so that the logic operator sits left under the
-	      ;; where clause
-	      (when (and (equal clause "where")
-			 (looking-at "and\\|or"))
-		(setf indentation base-indentation))
-	      indentation))))))
->>>>>>> Start workgin on aligning keywords left or right.
 
 (defun sqlind-right-justify-clause (syntax base-indentation)
   "Return an indentation which right-aligns the first word at
@@ -1909,13 +1878,9 @@ To use it, select the region to be aligned and type
 
 See also `align' and `align-rules-list'")
 
-(provide 'sql-indent)
-
 ;;;; sqlind-setup
-(require 'sql-indent-left)
 
 ;;;###autoload
-<<<<<<< HEAD
 (define-minor-mode sqlind-minor-mode
     "Toggle SQL syntactic indentation on or off.
 With syntactic indentation, hitting TAB on a line in a SQL buffer
@@ -1946,19 +1911,9 @@ column aliases in select statements."
   "Enable SQL syntactic indentation unconditionally.
 This function is deprecated, consider using `sqlind-minor-mode'
 instead."
-=======
-(defun sqlind-setup (&optional direction)
->>>>>>> Start workgin on aligning keywords left or right.
   (set (make-local-variable 'indent-line-function) 'sqlind-indent-line)
   (define-key sql-mode-map [remap beginning-of-defun] 'sqlind-beginning-of-statement)
-  (setq align-mode-rules-list sqlind-align-rules)
-  (if (eq direction 'left)
-      (setq sqlind-indentation-offsets-alist sqlind-indentation-left-offsets-alist)
-    (setq sqlind-indentation-offsets-alist sqlind-indentation-right-offsets-alist)))
-
-;; (add-hook 'sql-mode-hook
-;;           (lambda ()
-;;             (sqlind-setup 'left)))
+  (setq align-mode-rules-list sqlind-align-rules))
 
 (provide 'sql-indent)
 

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -221,12 +221,28 @@ they are one-line only directives."
                 (ms sqlind-ms-directive)
                 (sqlite sqlind-sqlite-directive)
                 (oracle sqlind-sqlplus-directive)
-                (t nil))))
+                (t nil)))
+	  (directive-start)
+	  (match-start))
       (when rx
         (save-excursion
           (when (re-search-backward rx nil 'noerror)
-            (forward-line 1)
-            (point)))))))
+	    (setq match-start (match-beginning 0))
+	    (forward-line 1)
+	    (setq directive-start (point))
+	    (when (string-equal "set" (match-string 0))
+	      (let* ((update-start (or (re-search-backward "\\_<update\\_>" nil 'noerror)
+					 (1+ directive-start)))
+		       (update-end (or (re-search-forward ";" nil 'noerror)
+				       (1- directive-start))))
+		(when (and (<= update-start directive-start)
+			   (>= update-end directive-start))
+		  (goto-char match-start)
+		  (setq directive-start nil)
+		  (when (re-search-backward rx nil 'noerror)
+		    (forward-line 1)
+		    (setq directive-start (point)))))))))
+      directive-start)))
 
 (defun sqlind-beginning-of-statement-1 (limit)
   "Return the position of a block start, or nil.
@@ -811,7 +827,7 @@ See also `sqlind-beginning-of-block'"
 	    (throw 'finished
 	      (if (looking-at "select")
 		  (sqlind-syntax-in-select pos match-pos)
-		  (cons (list 'in-insert-clause clause) match-pos)))))))))
+		(cons (list 'in-insert-clause clause) match-pos)))))))))
 
 
 ;;;;; Determine the syntax inside a delete statement
@@ -1429,7 +1445,7 @@ clause (select, from, where, etc) in which the current point is.
     (select-join-condition          ++)
     (select-table                   sqlind-indent-select-table)
     (select-table-continuation      sqlind-indent-select-table +)
-    (in-select-clause               sqlind-lineup-to-clause-end sqlind-adjust-and-or)
+    (in-select-clause               sqlind-lineup-to-clause-end sqlind-adjust-and-or-right)
     (insert-clause                  sqlind-right-justify-clause)
     (in-insert-clause               sqlind-lineup-to-clause-end)
     (delete-clause                  sqlind-right-justify-clause)
@@ -1688,7 +1704,7 @@ keyword ends."
         ;; otherwise, align to the end of the clause, with a few exceptions
         (current-column)))))
 
-(defun sqlind-adjust-and-or (syntax base-indentation)
+(defun sqlind-adjust-and-or-right (syntax base-indentation)
   "Align an AND or OR operator with the end of the WHERE clause.
 If this rule is added to the 'in-select-clause syntax after the
 `sqlind-lineup-to-clause-end' rule, it will adjust lines starting
@@ -1696,11 +1712,68 @@ with AND or OR to be aligned so they sit under the WHERE clause."
   (save-excursion
     (back-to-indentation)
     (destructuring-bind ((sym clause) . anchor) (car syntax)
-      (if (and (eq sym 'in-select-clause)
-               (equal clause "where")
+      (if (and (equal clause "where")
                (looking-at "and\\|or"))
           (- base-indentation (1+ (- (match-end 0) (match-beginning 0))))
         base-indentation))))
+
+(defun sqlind-adjust-and-or-left (syntax base-indentation)
+  "Align an AND or OR operator with the start of the WHERE clause.
+If this rule is added to the 'in-select-clause syntax after the
+`sqlind-lineup-to-clause-end' rule, it will adjust lines starting
+with AND or OR to be aligned so they sit left under the WHERE clause."
+  (save-excursion
+    (back-to-indentation)
+    (destructuring-bind ((sym clause) . anchor) (car syntax)
+      (if (and (equal clause "where")
+               (looking-at "and\\|or"))
+          (progn (goto-char anchor) (current-column))
+        base-indentation))))
+
+(defun sqlind-adjust-operator (_syntax base-indentation)
+  "Adjust the indentation for operators in select clauses.
+
+Select columns are lined up to the operands, not the operators.
+For example.
+
+    select col1, col2
+              || col3 as composed_column,
+           col4
+        || col5 as composed_column2
+    from   my_table
+    where  cond1 = 1
+    and    cond2 = 2;
+
+This is an indentation adjuster and needs to be added to the
+`sqlind-indentation-offsets-alist`"
+  (save-excursion
+    (back-to-indentation)
+    ;; If there are non-word constituents at the beginning if the line,
+    ;; consider them an operator and line up the line to the first word of the
+    ;; line, not the operator
+    (cond ((looking-at "\\W+")
+	   (let ((ofs (length (match-string 0))))
+	     (forward-line -1)
+	     (end-of-line)
+	     (sqlind-backward-syntactic-ws)
+	     (forward-sexp -1)
+	     (- (current-column) ofs)))
+	  ('t base-indentation))))
+
+(defun sqlind-lone-semicolon (syntax base-indentation)
+  "Indent a lone semicolon with the statement start.  For example:
+
+    select col
+    from my_table
+    ;
+
+This is an indentation adjuster and needs to be added to the
+`sqlind-indentation-offsets-alist`"
+  (save-excursion
+    (back-to-indentation)
+    (if (looking-at ";")
+        (sqlind-use-anchor-indentation syntax base-indentation)
+      base-indentation)))
 
 (defun sqlind-right-justify-clause (syntax base-indentation)
   "Return an indentation which right-aligns the first word at

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1674,6 +1674,7 @@ indentation so that:
 If the clause is on a line by itself, the current line is
 indented by `sqlind-basic-offset', otherwise the current line is
 indented so that it starts in next column from where the clause
+<<<<<<< HEAD
 keyword ends."
   (destructuring-bind ((_sym clause) . anchor) (car syntax)
     (save-excursion
@@ -1701,6 +1702,36 @@ with AND or OR to be aligned so they sit under the WHERE clause."
                (looking-at "and\\|or"))
           (- base-indentation (1+ (- (match-end 0) (match-beginning 0))))
         base-indentation))))
+=======
+keyword ends.
+
+An exception is made for a 'where' clause: if the current line
+starts with an 'and' or an 'or' the line is indented so that the
+and/or is right justified with the 'where' clause."
+  (let ((origin (point)))
+    (destructuring-bind ((_sym clause) . anchor) (car syntax)
+      (save-excursion
+	(goto-char anchor)
+	(forward-char (1+ (length clause)))
+	(skip-syntax-forward " ")
+	(if (or (looking-at sqlind-comment-start-skip)
+		(looking-at "$"))
+	    ;; if the clause is on a line by itself, indent this line
+	    ;; with a sqlind-basic-offset
+	    (+ base-indentation sqlind-basic-offset)
+	    ;; otherwise, align to the end of the clause, with a few
+	    ;; exceptions
+	    (let ((indentation (current-column)))
+	      (goto-char origin)
+	      (back-to-indentation)
+	      ;; when the line starts with an 'and' or an 'or', line
+	      ;; it up so that the logic operator sits left under the
+	      ;; where clause
+	      (when (and (equal clause "where")
+			 (looking-at "and\\|or"))
+		(setf indentation base-indentation))
+	      indentation))))))
+>>>>>>> Start workgin on aligning keywords left or right.
 
 (defun sqlind-right-justify-clause (syntax base-indentation)
   "Return an indentation which right-aligns the first word at
@@ -1878,9 +1909,13 @@ To use it, select the region to be aligned and type
 
 See also `align' and `align-rules-list'")
 
+(provide 'sql-indent)
+
 ;;;; sqlind-setup
+(require 'sql-indent-left)
 
 ;;;###autoload
+<<<<<<< HEAD
 (define-minor-mode sqlind-minor-mode
     "Toggle SQL syntactic indentation on or off.
 With syntactic indentation, hitting TAB on a line in a SQL buffer
@@ -1911,9 +1946,18 @@ column aliases in select statements."
   "Enable SQL syntactic indentation unconditionally.
 This function is deprecated, consider using `sqlind-minor-mode'
 instead."
+=======
+(defun sqlind-setup (&optional direction)
+>>>>>>> Start workgin on aligning keywords left or right.
   (set (make-local-variable 'indent-line-function) 'sqlind-indent-line)
   (define-key sql-mode-map [remap beginning-of-defun] 'sqlind-beginning-of-statement)
-  (setq align-mode-rules-list sqlind-align-rules))
+  (setq align-mode-rules-list sqlind-align-rules)
+  (when (eq direction 'left)
+    (setq sqlind-indentation-offsets-alist sqlind-indentation-left-offsets-alist)))
+
+;; (add-hook 'sql-mode-hook
+;;           (lambda ()
+;;             (sqlind-setup 'left)))
 
 (provide 'sql-indent)
 

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1705,28 +1705,28 @@ keyword ends."
         (current-column)))))
 
 (defun sqlind-adjust-and-or-right (syntax base-indentation)
-  "Align an AND or OR operator with the end of the WHERE clause.
+  "Align an AND, OR or NOT operator with the end of the WHERE clause.
 If this rule is added to the 'in-select-clause syntax after the
 `sqlind-lineup-to-clause-end' rule, it will adjust lines starting
-with AND or OR to be aligned so they sit under the WHERE clause."
+with AND, OR or NOT to be aligned so they sit under the WHERE clause."
   (save-excursion
     (back-to-indentation)
     (destructuring-bind ((sym clause) . anchor) (car syntax)
       (if (and (equal clause "where")
-               (looking-at "and\\|or"))
+               (looking-at "and\\|or\\|not"))
           (- base-indentation (1+ (- (match-end 0) (match-beginning 0))))
         base-indentation))))
 
 (defun sqlind-adjust-and-or-left (syntax base-indentation)
-  "Align an AND or OR operator with the start of the WHERE clause.
+  "Align an AND, OR or NOT operator with the start of the WHERE clause.
 If this rule is added to the 'in-select-clause syntax after the
 `sqlind-lineup-to-clause-end' rule, it will adjust lines starting
-with AND or OR to be aligned so they sit left under the WHERE clause."
+with AND, OR or NOT to be aligned so they sit left under the WHERE clause."
   (save-excursion
     (back-to-indentation)
     (destructuring-bind ((sym clause) . anchor) (car syntax)
       (if (and (equal clause "where")
-               (looking-at "and\\|or"))
+               (looking-at "and\\|or\\|not"))
           (progn (goto-char anchor) (current-column))
         base-indentation))))
 


### PR DESCRIPTION
This is the first step to add left or right aligment of keywords in sql statements.
With ```(sqlind-setup 'left)``` you could have :
```sql
select col1, col2
          || col3 as composed_column,
       col4
    || col5 as composed_column2
from   my_table
;

-- cursor cur_sel_colonne(p_column_name varchar2) is
select atc.column_name,
       atc.data_type,
       data_length,
       data_precision,
       nullable,
       data_scale,
       nvl(substr(comments, 1, 100), atc.column_name) comments
from   all_tab_columns atc,
       all_col_comments acc
where  atc.owner       = acc.owner
and    atc.table_name  = acc.table_name
and    atc.column_name = acc.column_name
and    atc.owner       = user
and    atc.table_name  = 'MY_TABLE'
and    atc.column_name = p_column_name
and    not exists (select 1
                   from   all_tab_columns atc1,
                          all_col_comments acc1
                   where  atc1.owner       = acc1.owner
                   and    atc1.table_name  = acc1.table_name
                   and    atc1.column_name = acc1.column_name
                   and    atc1.owner       = atc.owner
                   and    atc1.table_name  = atc.table_name
                   and    acc1.column_name = acc.column_name)
;

delete from my_table mt
where col_1 = v_col1
and  (   col_2 = v_col2
      or col_3 = v_col3)
and   col_42 = '42'
;

-- declare
--   function dummy(p_param_1 in     varchar2,
--                  p_param_2 in out varchar2,
--                  p_param_2    out varchar2)
--     return   boolean;
--   end dummy;

--   function dummy_2(p_param_1 out varchar2,
--                    p_param_2 out varchar2,
--                    p_param_2 out varchar2)
--     return   boolean;

--     function dummy_3(p_param_1     varchar2,
--                      p_param_2 in  varchar2,
--                      p_param_2 out varchar2)
--       return   boolean;

--       var1  boolean     := true;
--       var2  number      := 1;
--       var42 varchar2(1) := 'Y';
--     begin
--       if dummy(p_param_1  => val1,
--                p_param_10 => val10) then
--         null;
--       end if;
--     end;
--     /


select col1, col2
          || col3 as composed_column,
       col4
    || col5 as composed_column2
from   my_table
;

-- Local Variables:
-- mode: sql
-- tab-width: 2
-- indent-tabs-mode: nil
-- sql-product: oracle
-- eval: (sqlind-setup 'left)
-- End:
```
and with ```(sqlind-setup)``` :
```sql
select col1, col2
          || col3 as composed_column,
       col4
    || col5 as composed_column2
  from my_table
  ;


-- cursor cur_sel_colonne(p_column_name varchar2) is
select atc.column_name,
       atc.data_type,
       data_length,
       data_precision,
       nullable,
       data_scale,
       nvl(substr(comments, 1, 100), atc.column_name) comments
  from   all_tab_columns atc,
         all_col_comments acc
 where  atc.owner       = acc.owner
   and  atc.table_name  = acc.table_name
   and  atc.column_name = acc.column_name
   and  atc.column_name = p_column_name
   and  atc.owner       = user
   and  atc.table_name  = 'MY_TABLE'
   and  not exists (select 1
                      from all_tab_columns atc1,
                           all_col_comments acc1
                     where atc1.owner       = acc1.owner
                       and atc1.table_name  = acc1.table_name
                       and atc1.column_name = acc1.column_name
                       and atc1.owner       = atc.owner
                       and atc1.table_name  = atc.table_name
                       and acc1.column_name = acc.column_name)
 ;

delete from my_table mt
 where col_1 = v_col1
   and  (   col_2 = v_col2
         or col_3 = v_col3)
   and   col_42 = '42'
 ;

-- declare
--   function dummy(p_param_1 in     varchar2,
--                  p_param_2 in out varchar2,
--                  p_param_2    out varchar2)
--     return   boolean;
--   end dummy;

--   function dummy_2(p_param_1 out varchar2,
--                    p_param_2 out varchar2,
--                    p_param_2 out varchar2)
--     return   boolean;

--     function dummy_3(p_param_1     varchar2,
--                      p_param_2 in  varchar2,
--                      p_param_2 out varchar2)
--       return   boolean;

--       var1  boolean     := true;
--       var2  number      := 1;
--       var42 varchar2(1) := 'Y';
--     begin
--       if dummy(p_param_1  => val1,
--                p_param_10 => val10) then
--         null;
--       end if;
--     end;
--     /

-- Local Variables:
-- mode: sql
-- tab-width: 2
-- indent-tabs-mode: nil
-- sql-product: oracle
-- eval: (sqlind-setup)
-- End:
```
Again this is a first try. I know the code must be rearranged.