### PR TITLE
Use default value of indent-line-function when deactivating minor mode.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -1901,7 +1901,7 @@ column aliases in select statements."
         (define-key sql-mode-map [remap beginning-of-defun] 'sqlind-beginning-of-statement)
         (setq align-mode-rules-list sqlind-align-rules))
     (progn
-      (setq indent-line-function 'indent-relative)
+      (setq indent-line-function (default-value 'indent-line-function))
       (define-key sql-mode-map [remap beginning-of-defun] 'sql-beginning-of-statement)
       (setq align-mode-rules-list nil))))
 


### PR DESCRIPTION
As the user could change the value of indent-line-function, we could not reset it to 'indent-relative.