### PR TITLE
Exclude equals inside strings from alignments.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -2010,7 +2010,7 @@ determine how to indent each type of syntactic element."
 ;;;; Alignment rules
 
 (defvar sqlind-align-rules
-  '(;; Line up the two side of arrow =>
+  `(;; Line up the two side of arrow =>
     (sql-arrow-lineup
      (regexp . "\\(\\s-*\\)=>\\(\\s-*\\)")
      (modes quote (sql-mode))
@@ -2044,6 +2044,10 @@ determine how to indent each type of syntactic element."
      (modes quote (sql-mode))
      (group 1 2)
      (case-fold . t)
+     (valid . ,(function (lambda ()
+     			   (save-excursion
+     			     (goto-char (match-end 1))
+     			     (not (nth 3 (syntax-ppss (point))))))))
      (repeat . t))
     ;; lineup the column aliases (the "as name" part) in a select statement
     (sql-select-lineup-column-names


### PR DESCRIPTION
Don't align equal signs inside strings.

```sql
begin
  if var1    = 1 then
    var2 := 'some text with = inside';
  elsif var1 = 2 then
    var2 := 'another text with = inside';
  end if;
end;
/
```
instead of
```sql
begin
  if var1                      = 1 then
    var2 := 'some text with    = inside';
  elsif var1                   = 2 then
    var2 := 'another text with = inside';
  end if;
end;
/
```