### PR TITLE
Fix a typo and unify `sqlind-end-statement-regexp'.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -406,7 +406,7 @@ See also `sqlind-beginning-of-block'"
 		       (throw 'finished
 			 (list 'syntax-error
 			       "bad closing for if block" (point) pos))))))))
-	  ((looking-at (concant "\\(<<[a-z0-9_]+>>\\)?\\(?:" sqlind-ws-regexp "*\\)case\\_>"))
+	  ((looking-at (concat "\\(<<[a-z0-9_]+>>\\)?\\(?:" sqlind-ws-regexp "*\\)case\\_>"))
 	   ;; find the nearest when block, but only if there are no
 	   ;; end statements in the stack
 	   (let ((case-label (sqlind-match-string 1)))

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -131,7 +131,7 @@ whitespace, or at the end of the buffer."
       (goto-char (nth 8 pps))))
   (catch 'done
     (while t
-      (skip-chars-forward " \t\n\r\f\v")
+      (skip-chars-forward " \t\r\n\f\v")
       (cond ((looking-at sqlind-comment-start-skip) (forward-comment 1))
             ;; a slash ("/") by itself is a SQL*plus directive and
             ;; counts as whitespace

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -337,7 +337,7 @@ But don't go before LIMIT."
 ;;;;; Find the syntax and beginning of the current block
 
 (defconst sqlind-end-statement-regexp
-  "\\_<end_\\>\\(?:[ \n\r\t]*\\)\\(if\\_>\\|loop\\_>\\|case\\_>\\)?\\(?:[ \n\r\f]*\\)\\([a-z0-9_]+\\)?"
+  "\\_<end\\_>\\(?:[ \f\t\r\n]*\\)\\(\\_<\\(?:if\\|loop\\|case\\)\\_>\\)?\\(?:[ \f\t\r\n]*\\)\\([a-z0-9_]+\\)?"
   "Match an end of statement.
 Matches a string like \"end if|loop|case MAYBE-LABEL\".")
 
@@ -1323,7 +1323,7 @@ procedure block."
             ;; create a block-end syntax if needed
 
             ((and (not (eq syntax-symbol 'comment-continuation))
-                  (looking-at "end[ \t\r\n\f]*\\(\\_<\\(?:if\\|loop\\|case\\)\\_>\\)?[ \t\r\n\f]*\\(\\_<\\(?:[a-z0-9_]+\\)\\_>\\)?"))
+                  (looking-at sqlind-end-statement-regexp))
              ;; so we see the syntax which closes the current block.  We still
              ;; need to check if the current end is a valid closing block
              (let ((kind (or (sqlind-match-string 1) ""))


### PR DESCRIPTION
Fix a typo in ```sqlind-end-statement-regexp``` for "\\_>".
Unify the regexp with the one in ```sqlind-syntax-of-line```.