### PR TITLE
Correct display of lighter when minor-mode is enabled.

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -2178,7 +2178,7 @@ A set of alignment rules are also enabled with this minor mode.
 Selecting a region of text and typing `M-x align RET` will align
 the statements.  This can be used, for example, to align the 'as'
 column aliases in select statements."
-  :lighter "sqlind"
+  :lighter " sqlind"
   :group 'sqlind
   :global nil
   :init-value nil


### PR DESCRIPTION
Add an space before text to avoid it to stick on previous word in modeline.