### PR TITLE
Fix sqlind-lineup-close-paren-to-open-indentation close paren column

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -2082,6 +2082,7 @@ close paren."
               (progn
                 (goto-char (sqlind-anchor-point stx))
                 (back-to-indentation)
+                (back-to-indentation)
                 (current-column))
             base-indentation))
       base-indentation)))


### PR DESCRIPTION
- Previously, sqlind-lineup-close-paren-to-open-indentation would
  align the closing paren one indentation level too far to the right

- This is a pretty hacky fix; something more sophisticated may be
  desirable. It simply repeats the back-to-indentation command a
  second time to align the closing paren with the line it was started
  on