### PR TITLE
fix declare detection with locals qualifier

### DIFF
--- a/sql-indent.el
+++ b/sql-indent.el
@@ -652,7 +652,7 @@ See also `sqlind-beginning-of-block'"
               (save-excursion
                 (sqlind-backward-syntactic-ws)
                 (skip-syntax-backward "_w") ; note that the $$ is symbol constituent!
-                (looking-at "\\(\\$\\$\\)\\|begin\\|then\\|else")))
+                (looking-at "\\(\\$\\$\\)\\|begin\\|then\\|else\\|\\(<<[a-z0-9_]+>>\\)")))
       (throw 'finished
         (if (null sqlind-end-stmt-stack)
             'declare-statement


### PR DESCRIPTION
this patch fixes declare statement detection when there's a
`<<namespace>>` definition before it.

```sql
create or replace function something_great() returns integer as $$
    <<locals>>
    declare
        group_id       grp.id%TYPE;
        transaction_id integer;
begin
    select .....
```

local variables in the function are then used with `locals.` as prefix,
for example `locals.group_id`.